### PR TITLE
Create a unique mutagen session name per project

### DIFF
--- a/mutagen
+++ b/mutagen
@@ -100,7 +100,7 @@ create_mutagen_config() {
     permissions:
       defaultFileMode: 644
       defaultDirectoryMode: 755
-  code:
+  ${project_name}-cli:
     alpha: './'
     beta: '$beta'
     mode: 'two-way-resolved'" > mutagen.yml


### PR DESCRIPTION
When creating the `mutagen.yml` file, the mutagen session name is set to `code`. This causes problems when running multiple projects at the same time because there would be multiple syncs with the name "code".

This change adds the `$project_name` to the sync name to make it (more) unique.

`code` would become `${project_name}-cli`

Since `$project_name` is based on `COMPOSE_PROJECT_NAME_SAFE` it should not contain invalid characters.
